### PR TITLE
Us core 6 1 0

### DIFF
--- a/input/fsh/PFEClinicalTestObservation.fsh
+++ b/input/fsh/PFEClinicalTestObservation.fsh
@@ -2,7 +2,7 @@
 NOTE: Aliases are defined in GlobalAliasList.fsh
 **********/
 Profile:        PFEClinicalTestObservation
-Parent:         USCoreObservationClinicalTestResultProfile
+Parent:         USCoreObservationClinicalResultProfile
 Id:             pfe-observation-clinicaltest
 Title:          "Personal Functioning and Engagement Clinical Test Observation"
 Description:    "An exchange of post-acute care observation for a patient. This profile is used for exchanging a single piece of observation data that resulted from a clinical test."

--- a/input/fsh/PFECollection.fsh
+++ b/input/fsh/PFECollection.fsh
@@ -2,7 +2,7 @@
 NOTE: Aliases are defined in GlobalAliasList.fsh
 **********/
 Profile:        PFECollection
-Parent:         USCoreObservationSurveyProfile
+Parent:         USCoreSimpleObservationProfile
 Id:             pfe-collection
 Title:          "Personal Functioning and Engagement Collection"
 Description:    "A point in time collection of post-acute care observations for a patient. This profile is used for exchanging a set of observation data collected through the use of a structured resource (e.g., assessment tool, instrument, or screen) with multiple questions."
@@ -49,6 +49,6 @@ Description:    "A point in time collection of post-acute care observations for 
 * hasMember MS
 * hasMember ^short = "Each post-acute care observation in the collection. May also be another collection to support nested sections."
 
-* derivedFrom only Reference(USCoreQuestionnaireResponse or USCoreObservationSurveyProfile)
+* derivedFrom only Reference(USCoreQuestionnaireResponse or USCoreSimpleObservationProfile)
 * derivedFrom MS
 * derivedFrom ^short = "Should point back to the QuestionnaireResponse that this resource is derived from."

--- a/input/fsh/PFESingleObservation.fsh
+++ b/input/fsh/PFESingleObservation.fsh
@@ -2,7 +2,7 @@
 NOTE: Aliases are defined in GlobalAliasList.fsh
 **********/
 Profile:        PFESingleObservation
-Parent:         USCoreObservationSurveyProfile
+Parent:         USCoreSimpleObservationProfile
 Id:             pfe-observation-single
 Title:          "Personal Functioning and Engagement Single Observation"
 Description:    "An exchange of post-acute care observation for a patient. This profile is used for exchanging an observation for a single question generally included in a structured resource (e.g., assessment tool, instrument, or screen)."
@@ -43,6 +43,6 @@ Description:    "An exchange of post-acute care observation for a patient. This 
 * value[x] ^short = "Whenever possible should use the CodeableConcept datatype to provide a suitable code to define the concept for the observation data. As for values like an assessment score or roll-up value, the datatype for this element should be determined by Observation.code. However, for values that are ordinal, may use the CodeableConcept datatype along with the Ordinal Value Extension."
 
 * derivedFrom ^short = "Should point back to the QuestionnaireResponse that this resource is derived from."
-* derivedFrom only Reference(USCoreQuestionnaireResponse or USCoreObservationSurveyProfile)
+* derivedFrom only Reference(USCoreQuestionnaireResponse or USCoreSimpleObservationProfile)
 
 * hasMember 0..0

--- a/input/fsh/examples/Cognitive-PFECollection.instances.fsh
+++ b/input/fsh/examples/Cognitive-PFECollection.instances.fsh
@@ -7,7 +7,7 @@ InstanceOf: PFECollection
 Description: "Example PFE Collection for hospital MOCA assessment"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
 * effectiveDateTime = "2020-07-08T17:32:00-05:00"
@@ -24,7 +24,7 @@ Description: "Example PFE Collection for hospital MMSE assessment"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
 * effectiveDateTime = "2020-07-08T17:32:00-05:00"
 * code = http://loinc.org#72107-6 "Mini-Mental State Examination [MMSE]"
@@ -40,7 +40,7 @@ Description: "Example PFE Collection for SNF CAM assessment"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
 * effectiveDateTime = "2020-04-09T18:00:00-05:00"
 * code = http://loinc.org#86585-7 "MDS v3.0 - RAI v1.17.2, OASIS E - Signs and symptoms of delirium (from CAM) [CMS Assessment]"
@@ -58,7 +58,7 @@ Description: "Example PFE Collection for resident mood interview"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54635-8 "Resident mood interview (PHQ-9) [Reported PHQ-9 CMS]"
@@ -92,7 +92,7 @@ Description: "Example PFE Collection for SNF BIMS assessment"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52491-8 "Brief interview for mental status [BIMS]"
 * code.text = "Brief interview for mental status [BIMS]"
@@ -112,7 +112,7 @@ Description: "Example PFE Collection for SNF BIMS assessment: recall"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52493-4 "Recall [BIMS]"
 * code.text = "Recall"
@@ -131,7 +131,7 @@ Description: "Example PFE Collection for SNF BIMS assessment: temporal"
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54510-3 "Temporal orientation (orientation to year, month, and day) [BIMS]"
 * code.text = "Temporal orientation (orientation to year, month, and day)"

--- a/input/fsh/examples/Cognitive-PFEObservation.instances.fsh
+++ b/input/fsh/examples/Cognitive-PFEObservation.instances.fsh
@@ -10,7 +10,7 @@ Description: "Example PFE Observation: Total score [MoCA]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T17:32:00-05:00"
 * code = http://loinc.org#72172-0 "Total score [MoCA]"
 * performer[+] = Reference(PFEIG-Role-SLP-JennyGlass)
@@ -27,7 +27,7 @@ Description: "Example PFE Observation: Total score [MMSE]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T17:32:00-05:00"
 * code = http://loinc.org#72106-8 "Total score [MMSE]"
 * performer[+] = Reference(PFEIG-Role-SLP-JennyGlass)
@@ -44,7 +44,7 @@ Description: "Example PFE Observation: Inattention in last 7 days [CAM.CMS]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-04-09T18:00:00-05:00"
 * code = http://loinc.org#54628-3 "Inattention in last 7 days [CAM.CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -60,7 +60,7 @@ Description: "Example PFE Observation: Disorganized thinking in last 7 days [CAM
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-04-09T18:00:00-05:00"
 * code = http://loinc.org#54629-1 "Disorganized thinking in last 7 days [CAM.CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -76,7 +76,7 @@ Description: "Example PFE Observation: Acute onset mental status change [CAM.CMS
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-04-09T18:00:00-05:00"
 * code = http://loinc.org#54632-5 "Acute onset mental status change [CAM.CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -92,7 +92,7 @@ Description: "Example PFE Observation: Feeling tired or having little energy in 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54643-2 "Feeling tired or having little energy in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -108,7 +108,7 @@ Description: "Example PFE Observation: Poor appetite or overeating in last 2 wee
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54644-0 "Poor appetite or overeating in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -124,7 +124,7 @@ Description: "Example PFE Observation: Feeling down, depressed or hopeless in la
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54639-0 "Feeling down, depressed or hopeless in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -140,7 +140,7 @@ Description: "Example PFE Observation: Trouble falling or staying asleep, or sle
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54640-8 "Trouble falling or staying asleep, or sleeping too much in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -156,7 +156,7 @@ Description: "Example PFE Observation: Trouble falling or staying asleep, or sle
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54641-6 "Trouble falling or staying asleep, or sleeping too much in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -172,7 +172,7 @@ Description: "Example PFE Observation: Feeling tired or having little energy in 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54642-4 "Feeling tired or having little energy in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -188,7 +188,7 @@ Description: "Example PFE Observation: Little interest or pleasure in doing thin
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54636-6 "Little interest or pleasure in doing things in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -204,7 +204,7 @@ Description: "Example PFE Observation: Little interest or pleasure in doing thin
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54637-4 "Little interest or pleasure in doing things in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -220,7 +220,7 @@ Description: "Example PFE Observation: Feeling down, depressed or hopeless in la
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54638-2 "Feeling down, depressed or hopeless in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -236,7 +236,7 @@ Description: "Example PFE Observation: Moving or speaking so slowly that other p
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54650-7 "Moving or speaking so slowly that other people could have noticed. Or the opposite - being so fidgety or restless that you have been moving around a lot more than usual in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -252,7 +252,7 @@ Description: "Example PFE Observation: Trouble concentrating on things, such as 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54649-9 "Trouble concentrating on things, such as reading the newspaper or watching television in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -268,7 +268,7 @@ Description: "Example PFE Observation: Thoughts that you would be better off dea
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54652-3 "Thoughts that you would be better off dead, or of hurting yourself in some way in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -284,7 +284,7 @@ Description: "Example PFE Observation: Moving or speaking so slowly that other p
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54651-5 "Moving or speaking so slowly that other people could have noticed. Or the opposite - being so fidgety or restless that you have been moving around a lot more than usual in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -300,7 +300,7 @@ Description: "Example PFE Observation: Feeling bad about yourself - or that you 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54646-5 "Feeling bad about yourself - or that you are a failure or have let yourself or your family down in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -316,7 +316,7 @@ Description: "Example PFE Observation: Poor appetite or overeating in last 2 wee
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54645-7 "Poor appetite or overeating in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -332,7 +332,7 @@ Description: "Example PFE Observation: Trouble concentrating on things, such as 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54648-1 "Trouble concentrating on things, such as reading the newspaper or watching television in last 2 weeks.presence [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -348,7 +348,7 @@ Description: "Example PFE Observation: Feeling bad about yourself - or that you 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54647-3 "Feeling bad about yourself - or that you are a failure or have let yourself or your family down in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -364,7 +364,7 @@ Description: "Example PFE Observation: Mood interview total severity score [Repo
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54654-9 "Mood interview total severity score [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -381,7 +381,7 @@ Description: "Example PFE Observation: Thoughts that you would be better off dea
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54653-1 "Thoughts that you would be better off dead, or of hurting yourself in some way in last 2 weeks.frequency [Reported PHQ-9 CMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-LunaBaskins)
@@ -397,7 +397,7 @@ Description: "Example PFE Observation: Temporal orientation - current year [BIMS
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52732-5 "Temporal orientation - current year [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -413,7 +413,7 @@ Description: "Example PFE Observation: Recall - bed [BIMS]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52737-4 "Recall - bed [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -429,7 +429,7 @@ Description: "Example PFE Observation: Recall - blue [BIMS]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52736-6 "Recall - blue [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -445,7 +445,7 @@ Description: "Example PFE Observation: Recall - sock [BIMS]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52735-8 "Recall - sock [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -461,7 +461,7 @@ Description: "Example PFE Observation: Temporal orientation - current day of the
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54609-3 "Temporal orientation - current day of the week [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -477,7 +477,7 @@ Description: "Example PFE Observation: Temporal orientation - current month [BIM
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52733-3 "Temporal orientation - current month [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -493,7 +493,7 @@ Description: "Example PFE Observation: Repetition of three words # [BIMS]"
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#52731-7 "Repetition of three words # [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)
@@ -509,7 +509,7 @@ Description: "Example PFE Observation: Brief Interview for Mental Status - summa
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-b11 "Mental functions"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T11:30:00-05:00"
 * code = http://loinc.org#54614-3 "Brief Interview for Mental Status - summary score [BIMS]"
 * performer[+] = Reference(PFEIG-Role-SLP-HoneyJones)

--- a/input/fsh/examples/Functional-PFECollection.instances.fsh
+++ b/input/fsh/examples/Functional-PFECollection.instances.fsh
@@ -9,7 +9,7 @@ Description: "Example PFE Collection of mobility observations for hospital disch
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#88331-4 "Mobility - discharge performance during 3 day assessment period [CMS Assessment]"
@@ -47,7 +47,7 @@ Description: "Example PFE Collection of mobility observations for hospital admis
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#88330-6 "Mobility - admission performance during 3 day assessment period [CMS Assessment]"
@@ -82,7 +82,7 @@ Description: "Example PFE Collection of self-care observations for SNF admission
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83233-7 "Self-care - admission performance [CMS Assessment]"

--- a/input/fsh/examples/Functional-PFEObservation.instances.fsh
+++ b/input/fsh/examples/Functional-PFEObservation.instances.fsh
@@ -10,7 +10,7 @@ Description: "Example PFE Observation: 4 steps - functional ability during 3 day
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83194-1 "4 steps - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -26,7 +26,7 @@ Description: "Example PFE Observation: 12 steps - functional ability during 3 da
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83192-5 "12 steps - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -42,7 +42,7 @@ Description: "Example PFE Observation: Walking 10 feet on uneven surfaces - func
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83198-2 "Walking 10 feet on uneven surfaces - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -58,7 +58,7 @@ Description: "Example PFE Observation: 1 step (curb) - functional ability during
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83196-6 "1 step (curb) - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -74,7 +74,7 @@ Description: "Example PFE Observation: Picking up object - functional ability du
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83190-9 "Picking up object - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -90,7 +90,7 @@ Description: "Example PFE Observation: Lower body dressing - functional ability 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83222-0 "Lower body dressing - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -106,7 +106,7 @@ Description: "Example PFE Observation: Walk 50 feet with two turns - functional 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83202-2 "Walk 50 feet with two turns - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -122,7 +122,7 @@ Description: "Example PFE Observation: Walk 10 feet - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83204-8 "Walk 10 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -138,7 +138,7 @@ Description: "Example PFE Observation: Car transfer - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83206-3 "Car transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -154,7 +154,7 @@ Description: "Example PFE Observation: Toilet transfer - functional ability duri
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83208-9 "Toilet transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -170,7 +170,7 @@ Description: "Example PFE Observation: Bed-to-chair transfer - functional abilit
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83210-5 "Bed-to-chair transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -186,7 +186,7 @@ Description: "Example PFE Observation: Wheel 150 feet - functional ability durin
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83235-2 "Wheel 150 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -202,7 +202,7 @@ Description: "Example PFE Observation: Picking up object - functional ability du
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83190-9 "Picking up object - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -218,7 +218,7 @@ Description: "Example PFE Observation: Wheel 50 feet with two turns - functional
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83188-3 "Wheel 50 feet with two turns - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -234,7 +234,7 @@ Description: "Example PFE Observation: Bed-to-chair transfer - functional abilit
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83210-5 "Bed-to-chair transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -250,7 +250,7 @@ Description: "Example PFE Observation: Walk 150 feet - functional ability during
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83200-6 "Walk 150 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -266,7 +266,7 @@ Description: "Example PFE Observation: Oral hygiene - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83230-3 "Oral hygiene - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -282,7 +282,7 @@ Description: "Example PFE Observation: Sit to lying - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83216-2 "Sit to lying - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -298,7 +298,7 @@ Description: "Example PFE Observation: Walk 50 feet with two turns - functional 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83202-2 "Walk 50 feet with two turns - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -314,7 +314,7 @@ Description: "Example PFE Observation: Eating - functional ability during 3 day 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83232-9 "Eating - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -330,7 +330,7 @@ Description: "Example PFE Observation: Sit to stand - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83212-1 "Sit to stand - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -346,7 +346,7 @@ Description: "Example PFE Observation: Lying to sitting on side of bed - functio
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83214-7 "Lying to sitting on side of bed - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -362,7 +362,7 @@ Description: "Example PFE Observation: Wheel 150 feet - functional ability durin
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83235-2 "Wheel 150 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -378,7 +378,7 @@ Description: "Example PFE Observation: Wheel 50 feet with two turns - functional
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83188-3 "Wheel 50 feet with two turns - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -394,7 +394,7 @@ Description: "Example PFE Observation: 12 steps - functional ability during 3 da
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83192-5 "12 steps - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -410,7 +410,7 @@ Description: "Example PFE Observation: Walk 10 feet - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83204-8 "Walk 10 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -426,7 +426,7 @@ Description: "Example PFE Observation: Roll left and right - functional ability 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83218-8 "Roll left and right - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -442,7 +442,7 @@ Description: "Example PFE Observation: Toileting hygiene - functional ability du
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83228-7 "Toileting hygiene - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -458,7 +458,7 @@ Description: "Example PFE Observation: Roll left and right - functional ability 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83218-8 "Roll left and right - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -474,7 +474,7 @@ Description: "Example PFE Observation: Lying to sitting on side of bed - functio
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83214-7 "Lying to sitting on side of bed - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -490,7 +490,7 @@ Description: "Example PFE Observation: Shower/bathe self - functional ability du
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83226-1 "Shower/bathe self - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -506,7 +506,7 @@ Description: "Example PFE Observation: Sit to lying - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83216-2 "Sit to lying - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -522,7 +522,7 @@ Description: "Example PFE Observation: Walking 10 feet on uneven surfaces - func
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83198-2 "Walking 10 feet on uneven surfaces - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -538,7 +538,7 @@ Description: "Example PFE Observation: Walk 150 feet - functional ability during
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83200-6 "Walk 150 feet - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -554,7 +554,7 @@ Description: "Example PFE Observation: Sit to stand - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83212-1 "Sit to stand - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -570,7 +570,7 @@ Description: "Example PFE Observation: 4 steps - functional ability during 3 day
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83194-1 "4 steps - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -586,7 +586,7 @@ Description: "Example PFE Observation: 1 step (curb) - functional ability during
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#83196-6 "1 step (curb) - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-RonMarble)
@@ -602,7 +602,7 @@ Description: "Example PFE Observation: Toilet transfer - functional ability duri
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83208-9 "Toilet transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -618,7 +618,7 @@ Description: "Example PFE Observation: Putting on/taking off footwear - function
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83220-4 "Putting on/taking off footwear - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)
@@ -634,7 +634,7 @@ Description: "Example PFE Observation: Car transfer - functional ability during 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-08T16:00:00-05:00"
 * code = http://loinc.org#83206-3 "Car transfer - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-PT-SallySmith)
@@ -650,7 +650,7 @@ Description: "Example PFE Observation: Upper body dressing - functional ability 
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d51 "Self-care"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * effectiveDateTime = "2020-07-11T16:32:00-05:00"
 * code = http://loinc.org#83224-6 "Upper body dressing - functional ability during 3 day assessment period [CMS Assessment]"
 * performer[+] = Reference(PFEIG-Role-OT-JenCadbury)

--- a/input/fsh/examples/Nested-PFECollection.instances.fsh
+++ b/input/fsh/examples/Nested-PFECollection.instances.fsh
@@ -9,7 +9,7 @@ Description: "Example Nested Personal Functioning and Engagement Collection, ie.
 * subject = Reference(PFEIG-patientBSJ1)
 * status = #final
 * category[functioning] = FUNCTIONINGCAT#functioning "Functioning"
-* category[survey] = OBSCAT#survey
+* category[us-core] = OBSCAT#survey
 * category[PFEDomain] = PFEDOMAINCAT#BlockL2-d41 "Mobility"
 * effectiveDateTime = "2020-07-10T14:34:00-05:00"
 * code = http://loinc.org#88331-4 "Mobility - discharge performance during 3 day assessment period [CMS Assessment]"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -35,7 +35,7 @@ contact:
 license: CC0-1.0
 fhirVersion: 4.0.1
 dependencies:
-  hl7.fhir.us.core: 5.0.1
+  hl7.fhir.us.core: 6.1.0
 parameters:
   path-expansion-params: '../../input/_resources/terminology-settings.json'  # for using US ed of SNOMED
   show-inherited-invariants: false


### PR DESCRIPTION
Update sushi-config.yaml to derive US Core profiles from US Core 6.1.0 (previously 5.0.1) to comply with the HT1 rule that goes into effect on January 1, 2025. Since the US Core Survey Observation no longer exists in US Core 6.1.0, instead use the US Core Simple Observation profile with a category of "survey." Make the corresponding update to all sample instances that previously used US Core Survey Observation.