### PR TITLE
reverse cross version extensions url

### DIFF
--- a/input/fsh/Extensions.fsh
+++ b/input/fsh/Extensions.fsh
@@ -46,7 +46,6 @@ Id: pfe-clinical-justification
 Extension: PFEDeviceRequestLocation
 Description: "Cross-version extension to carry DeviceRequest.location from FHIR R6 on an R4 DeviceRequest."
 Id: pfe-device-request-location
-* ^url = "http://hl7.org/fhir/6.0/StructureDefinition/extension-DeviceRequest.location"
 * ^context.type = #element
 * ^context.expression = "DeviceRequest"
 * extension contains
@@ -60,7 +59,6 @@ Id: pfe-device-request-location
 Extension: PFEDeviceRequestAdditionalRequester
 Description: "Cross-version extension to carry FHIR R6 DeviceRequest.requester targets that are not allowed in FHIR R4."
 Id: pfe-device-request-additional-requester
-* ^url = "http://hl7.org/fhir/6.0/StructureDefinition/extension-DeviceRequest.requester"
 * ^context.type = #element
 * ^context.expression = "DeviceRequest.requester"
 * value[x] only Reference(CareTeam or Group or Patient or RelatedPerson)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -47,9 +47,6 @@ parameters:
   apply-jurisdiction: true
   apply-publisher: true
   pin-canonicals: 'pin-multiples'
-  special-url:
-    - http://hl7.org/fhir/6.0/StructureDefinition/extension-DeviceRequest.location
-    - http://hl7.org/fhir/6.0/StructureDefinition/extension-DeviceRequest.requester
 copyrightYear: 2022+
 releaseLabel: STU 2
 jurisdiction: urn:iso:std:iso:3166#US


### PR DESCRIPTION
Remove cross version extension urls because US Core v6.0 is not released yet. Using v6-v4 cross version url could cause confusion. 